### PR TITLE
fix: update chaitin-waf.lua to support unix sock in host pattern

### DIFF
--- a/apisix/plugins/chaitin-waf.lua
+++ b/apisix/plugins/chaitin-waf.lua
@@ -95,7 +95,7 @@ local metadata_schema = {
                 properties = {
                     host = {
                         type = "string",
-                        pattern = "^\\*?[0-9a-zA-Z-._\\[\\]:]+$"
+                        pattern = "^\\*?[0-9a-zA-Z-._\\[\\]:/]+$"
                     },
                     port = {
                         type = "integer",

--- a/t/plugin/chaitin-waf.t
+++ b/t/plugin/chaitin-waf.t
@@ -136,6 +136,10 @@ __DATA__
                         {
                             "host": "127.0.0.1",
                             "port": 8089
+                        },
+                        {
+                            "host": "unix:/path/to/safeline/resources/detector/snserver.sock",
+                            "port": 8000
                         }
                     ]
                  }]]


### PR DESCRIPTION
### Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->

support UNIX sock URL like `unix:/path/to/safeline/resources/detector/snserver.sock`

### Checklist

- [x] I have explained the need for this PR and the problem it solves
- [x] I have explained the changes or the new features added to this PR
- [x] I have added tests corresponding to this change
- [x] I have updated the documentation to reflect this change
- [x] I have verified that this change is backward compatible (If not, please discuss on the [APISIX mailing list](https://github.com/apache/apisix/tree/master#community) first)

<!--

Note

1. Mark the PR as draft until it's ready to be reviewed.
2. Always add/update tests for any changes unless you have a good reason.
3. Always update the documentation to reflect the changes made in the PR.
4. Make a new commit to resolve conversations instead of `push -f`.
5. To resolve merge conflicts, merge master instead of rebasing.
6. Use "request review" to notify the reviewer after making changes.
7. Only a reviewer can mark a conversation as resolved.

-->
